### PR TITLE
Parser Checks 2

### DIFF
--- a/Sources/PranceCore/Checking/ASTChecker.swift
+++ b/Sources/PranceCore/Checking/ASTChecker.swift
@@ -93,7 +93,9 @@ extension ASTChecker {
     case .whileLoop(let cond, let body, _):
       try checkRecursive(expr: cond, parameterValues: parameterValues, checker: checker)
       try body.forEach { try checkRecursive(expr: $0, parameterValues: parameterValues, checker: checker) }
-    case .literal, .variable, .variableDefinition:
+    case .variableDefinition(let definition, _):
+      parameterValues.addVariable(name: definition.name, type: definition.type, value: nil)
+    case .literal, .variable:
       break
     }
   }

--- a/Sources/PranceCore/Checking/FunctionReturnTypeChecker.swift
+++ b/Sources/PranceCore/Checking/FunctionReturnTypeChecker.swift
@@ -1,0 +1,46 @@
+//
+//  FunctionReturnTypeChecker.swift
+//  PranceCore
+//
+//  Created by Tristan Burnside on 3/5/21.
+//
+
+import Foundation
+
+final class FunctionReturnTypeChecker: ASTChecker {
+  let file: File
+  
+  init(file: File) {
+    self.file = file
+  }
+  
+  func check() throws {
+    for function in file.functions {
+      try checkFunctionReturn(function)
+    }
+  }
+  
+  func checkFunctionReturn(_ function: FunctionDefinition) throws {
+    let returnedType = function.typedExpr.last?.type ?? VoidStore()
+    let typeNames = validTypeNames(for: function.prototype.returnType)
+    guard typeNames.contains(returnedType.name) else {
+      throw ParseError.returnTypeMismatch(expected: function.prototype.returnType.name, got: returnedType.name)
+    }
+  }
+  
+  private func validTypeNames(for storedType: StoredType) -> [String] {
+    if let type = file.customTypes.first(where: { (type) -> Bool in
+      type.name == storedType.name
+    }) {
+      return [type.name]
+    }
+    if let proto = file.protocols.first(where: { (proto) -> Bool in
+      proto.name == storedType.name
+    }) {
+      let types = file.customTypes.filter { $0.protocols.contains(proto.name) }
+      let typeNames = types.map { $0.name }
+      return typeNames + [proto.name]
+    }
+    return [storedType.name]
+  }
+}

--- a/Sources/PranceCore/Checking/VariableDefinitionTypeChecker.swift
+++ b/Sources/PranceCore/Checking/VariableDefinitionTypeChecker.swift
@@ -1,0 +1,30 @@
+//
+//  VariableDefinitionTypeChecker.swift
+//  PranceCore
+//
+//  Created by Tristan Burnside on 3/5/21.
+//
+
+import Foundation
+
+final class VariableDefinitionTypeChecker: ASTChecker {
+  let file: File
+  
+  init(file: File) {
+    self.file = file
+  }
+  
+  func check() throws {
+    try checkExpr { (expr, parameterValues) in
+      switch expr {
+      case .variableDefinition(_, let type):
+        if let customType = type as? CustomStore,
+           allTypes[customType.name] == nil {
+          throw ParseError.undefinedType(customType.name, FilePosition(line: 0, position: 0))
+        }
+      default:
+        break
+      }
+    }
+  }
+}

--- a/Sources/PranceCore/Parsing/Parser.swift
+++ b/Sources/PranceCore/Parsing/Parser.swift
@@ -108,6 +108,7 @@ enum ParseError: Error {
   case typeDoesNotContainMembers(String)
   case unexpectedArgumentInCall(got: String, expected: String)
   case wrongType(expectedType:String, for: String, got: String)
+  case returnTypeMismatch(expected: String, got: String)
 }
 
 extension String {

--- a/Sources/PranceCore/PranceCore.swift
+++ b/Sources/PranceCore/PranceCore.swift
@@ -35,7 +35,11 @@ public struct PranceCompiler {
     
     let file = try Parser(tokens: toks).parseFile()
     
-    let checkers: [ASTChecker.Type] = [TypeResolver.self, ProtocolConformanceChecker.self, FunctionCallChecker.self]
+    let checkers: [ASTChecker.Type] = [TypeResolver.self,
+                                       ProtocolConformanceChecker.self,
+                                       FunctionCallChecker.self,
+                                       FunctionReturnTypeChecker.self,
+                                       VariableDefinitionTypeChecker.self]
     try checkers.map { $0.init(file: file) }.forEach { try $0.check() }
     
     let irGen = IRGenerator(file: file)


### PR DESCRIPTION
Add checks for function return types matching definitions and for variable definitions to be of declared (or primitive) types.